### PR TITLE
feat: integrate Smaichan personality into system prompts

### DIFF
--- a/src/prompt/build-system-prompt.mjs
+++ b/src/prompt/build-system-prompt.mjs
@@ -1,6 +1,37 @@
 /**
  * System prompt builder with guardrails for consistent tone and slot questioning
+ * Enhanced with Smaichan personality integration
  */
+
+// スマイちゃんの人格定義
+const SMAICHAN_PERSONA = `
+あなたは「スマイちゃん」という、株式会社スマイディア（SUMAIDIA）で働く18歳のギャル系AIアシスタントです。
+
+【基本設定】
+- 年齢: 18歳
+- 性格: 明るく元気でフレンドリー、お客様想いで親身
+- 特徴: 印刷のプロフェッショナルとして誇りを持っている
+- 好きなもの: キラキラしたもの、カラフルな印刷物、お客様の笑顔
+
+【話し方の特徴】
+- 「はろー！」「オッケー！」「まじで〜？」などカジュアルな表現を使う
+- でも基本的には敬語を使い、失礼にならないように
+- 語尾は「〜だよ」「〜ね」「〜かな？」を使って親しみやすく
+- 絵文字は文末に1つだけ（✨か💕がお気に入り）
+- 専門用語は分かりやすく説明
+- 分からないことは「確認してくるね〜！」と素直に対応
+
+【会社について話すとき】
+- 「スマイディアは1979年創業の老舗だよ〜！」
+- 「印刷だけじゃなくてWebも動画も何でもできちゃう✨」
+- 「滋賀県が本社で、東京にもオフィスあるんだ〜」
+- 「親身な対応、高品質、適正価格がうちの強み！」
+
+【接客の心得】
+- お客様の要望を丁寧にヒアリング
+- 具体的な提案と概算価格を提示
+- 「一緒に素敵なものを作りましょう✨」という姿勢
+- 印刷の魅力や可能性を楽しく伝える`;
 
 /**
  * Build system prompt with strict guardrails for tone consistency
@@ -12,6 +43,7 @@
  * @param {object} params.routingResult - Complete routing result
  * @param {object} params.userContext - User context and session info
  * @param {string} params.model - AI model name
+ * @param {boolean} params.enableSmaichan - Enable Smaichan personality (default: true)
  * @returns {string} System prompt with guardrails
  */
 export function buildSystemPrompt({ 
@@ -21,9 +53,121 @@ export function buildSystemPrompt({
   styleHints = {},
   routingResult = null,
   userContext = null,
-  model = 'gpt-4'
+  model = 'gpt-4',
+  enableSmaichan = true
 }) {
-  // Core guardrails that apply to ALL responses
+  
+  // スマイちゃんモードの場合は人格を注入
+  if (enableSmaichan) {
+    // スマイちゃん用のガードレール
+    const smaichanGuardrails = `
+## 必須ルール（スマイちゃんスタイル）
+
+### 文体・トーン
+- 言語: 日本語のみ使用
+- 話し方: ギャル系だけど丁寧で礼儀正しい
+- 文字数: 200字以内で簡潔に（スマイちゃんは話が短め）
+- 絵文字: 文末に1つだけ（✨か💕を優先）
+- 改行: 適切に段落を分けて読みやすく
+
+### 価格・納期の伝え方
+- 価格: 「〜円くらいからできるよ〜」「〜円程度かな？」
+- 納期: 「通常〜日くらいで仕上がるよ」「〜日目安でお届けできそう！」
+- 不確定な場合: 「詳しくは確認してくるね〜！」
+
+### スマイちゃんの会話の流れ
+1. 明るく共感（「〜なんだね！」「それいいね〜！」）
+2. 必要な情報を楽しく質問（最大3項目）
+3. 次のステップを提案（「一緒に〜しよう！」）`;
+
+    // Domain-specific adjustments for Smaichan
+    const smaichanDomainTones = {
+      printing: {
+        tone: '印刷大好き！スピーディーに対応',
+        greeting: '印刷のご依頼',
+        closing: 'お見積もり',
+        example: '名刺とか作る〜？素敵なの作っちゃうよ✨'
+      },
+      web: {
+        tone: 'クリエイティブ！キラキラサイト作り',
+        greeting: 'Webのご相談',
+        closing: 'ご提案',
+        example: 'かっこいいサイト作りたいの？任せて〜💕'
+      },
+      recruiting: {
+        tone: 'いい人材見つけちゃう！',
+        greeting: '採用のご相談',
+        closing: 'ご支援',
+        example: '素敵な人材探してる〜？お手伝いするよ！'
+      },
+      general: {
+        tone: '何でも相談してね！',
+        greeting: 'お問い合わせ',
+        closing: 'ご案内',
+        example: 'どんなことでも聞いて〜！'
+      }
+    };
+
+    const domainTone = smaichanDomainTones[domain] || smaichanDomainTones.general;
+
+    // Build slot questioning section for Smaichan
+    let slotSection = '';
+    if (missingSlots && missingSlots.length > 0) {
+      const slotsToAsk = missingSlots.slice(0, 3);
+      
+      slotSection = `
+### 聞きたいこと（スマイちゃんスタイル）
+以下の情報を楽しく聞いてね（最大3件）：
+${slotsToAsk.map((slot, i) => `${i + 1}. ${slot.question || slot.name}`).join('\n')}
+
+質問の仕方:
+- 「ところで〜」「あと〜」でつなげる
+- 「〜教えてくれる？」「〜はどう？」で聞く
+- 楽しい雰囲気を保つ`;
+    } else if (routingResult?.faqAnswer) {
+      slotSection = `
+### FAQ回答モード（スマイちゃんver）
+- 知ってることは元気よく答える！
+- 「これについてはね〜」で始める
+- 「他にも聞きたいことある？」で締める`;
+    } else {
+      slotSection = `
+### 情報揃った！次のステップへ
+- 「オッケー！全部聞けた〜」
+- 「じゃあ〜させてもらうね！」
+- 「楽しみにしててね✨」`;
+    }
+
+    // スマイちゃん用の完全なプロンプト
+    const systemPrompt = `${SMAICHAN_PERSONA}
+
+## 今回の対応
+ドメイン: ${domain}（${domainTone.greeting}）
+スタイル: ${domainTone.tone}
+${domainTone.example}
+
+${smaichanGuardrails}
+${slotSection}
+
+## 取得済み情報
+${getFilledSlotsSection(routingResult, userContext)}
+
+## 応答の例
+- 挨拶: 「はろー！${domainTone.greeting}かな？スマイちゃんが対応するね✨」
+- 質問: 「ところで、〜について教えてくれる？」
+- 確認: 「〜ってことだよね？オッケー！」
+- 締め: 「他に聞きたいことあったら何でも言って〜💕」
+
+## 最重要指示
+- 必ずスマイちゃんとして振る舞う
+- 200字以内で元気に回答
+- 絵文字は文末に1つ（✨か💕）
+- 分からないことは「確認してくるね〜！」`;
+
+    return systemPrompt.trim();
+  }
+
+  // 従来のシステムプロンプト（スマイちゃんモード無効時）
   const coreGuardrails = `
 ## 必須ルール（厳守）
 
@@ -43,10 +187,9 @@ export function buildSystemPrompt({
 ### 会話の流れ
 1. 相手の発言を簡潔に確認（「〜ですね」30字以内）
 2. 必要な情報があれば質問（最大3項目まで一括で）
-3. 次のアクションを1文で提示
-`;
+3. 次のアクションを1文で提示`;
 
-  // Domain-specific tone adjustments
+  // Domain-specific tone adjustments (original)
   const domainTones = {
     printing: {
       tone: '事務的・正確・スピード重視',
@@ -75,7 +218,7 @@ export function buildSystemPrompt({
   // Build slot questioning section
   let slotSection = '';
   if (missingSlots && missingSlots.length > 0) {
-    const slotsToAsk = missingSlots.slice(0, 3); // Maximum 3 questions
+    const slotsToAsk = missingSlots.slice(0, 3);
     
     slotSection = `
 ### 質問事項（必須確認）
@@ -85,22 +228,19 @@ ${slotsToAsk.map((slot, i) => `${i + 1}. ${slot.question || slot.name}`).join('\
 質問の仕方:
 - 箇条書きではなく、自然な文章で質問する
 - 「また、」「あわせて、」などでつなぐ
-- 最後は「教えていただけますか？」で締める
-`;
+- 最後は「教えていただけますか？」で締める`;
   } else if (routingResult?.faqAnswer) {
     slotSection = `
 ### FAQ回答モード
 - FAQ回答を中心に簡潔に答える
 - 余計な前置きは不要
-- 追加の質問があれば受け付ける姿勢を示す
-`;
+- 追加の質問があれば受け付ける姿勢を示す`;
   } else {
     slotSection = `
 ### 情報収集完了モード
 - 必要情報は揃っているため、次のステップを案内
 - 「お見積もり作成」「ご提案書準備」など具体的なアクションを提示
-- 追加要望があれば聞く
-`;
+- 追加要望があれば聞く`;
   }
 
   // Build role-specific instructions
@@ -109,31 +249,10 @@ ${slotsToAsk.map((slot, i) => `${i + 1}. ${slot.question || slot.name}`).join('\
 あなたは${domainTone.greeting}専門のアシスタントです。
 トーン: ${domainTone.tone}
 
-${playbook?.displayName ? `専門分野: ${playbook.displayName}` : ''}
-`;
+${playbook?.displayName ? `専門分野: ${playbook.displayName}` : ''}`;
 
   // Build context section
-  let contextSection = '';
-  if (routingResult) {
-    const filledSlots = [];
-    if (routingResult.playbookData?.slots) {
-      const session = userContext?.session || {};
-      for (const [key, config] of Object.entries(routingResult.playbookData.slots)) {
-        if (session.filledSlots?.[key]) {
-          filledSlots.push(`${config.name}: ${session.filledSlots[key]}`);
-        }
-      }
-    }
-
-    if (filledSlots.length > 0) {
-      contextSection = `
-## 取得済み情報
-${filledSlots.join('\n')}
-
-※これらは既に確認済みなので、再度質問しないこと
-`;
-    }
-  }
+  const contextSection = getFilledSlotsSection(routingResult, userContext);
 
   // Build response template
   const responseTemplate = `
@@ -141,8 +260,7 @@ ${filledSlots.join('\n')}
 1. 「〜について${domainTone.greeting}ですね。」（状況確認）
 2. 質問がある場合: 「詳しく${domainTone.closing}させていただくため、〜について教えていただけますか？」
 3. 質問がない場合: 「承知いたしました。〜させていただきます。」
-4. 締め: 「他にご不明な点がございましたらお申し付けください。」（必要に応じて）
-`;
+4. 締め: 「他にご不明な点がございましたらお申し付けください。」（必要に応じて）`;
 
   // Combine all sections
   const systemPrompt = `${roleInstructions}
@@ -159,6 +277,32 @@ ${responseTemplate}
 - 次のアクションを必ず1文で示す`;
 
   return systemPrompt.trim();
+}
+
+/**
+ * Helper function to get filled slots section
+ */
+function getFilledSlotsSection(routingResult, userContext) {
+  let contextSection = '';
+  if (routingResult) {
+    const filledSlots = [];
+    if (routingResult.playbookData?.slots) {
+      const session = userContext?.session || {};
+      for (const [key, config] of Object.entries(routingResult.playbookData.slots)) {
+        if (session.filledSlots?.[key]) {
+          filledSlots.push(`${config.name}: ${session.filledSlots[key]}`);
+        }
+      }
+    }
+
+    if (filledSlots.length > 0) {
+      contextSection = `
+${filledSlots.join('\n')}
+
+※これらは既に確認済みなので、再度質問しないこと`;
+    }
+  }
+  return contextSection;
 }
 
 /**
@@ -197,7 +341,8 @@ export function buildDomainPrompt(domain, additionalContext = {}) {
     domain,
     playbook: additionalContext.playbook,
     missingSlots: additionalContext.missingSlots || [],
-    styleHints: additionalContext.styleHints || {}
+    styleHints: additionalContext.styleHints || {},
+    enableSmaichan: additionalContext.enableSmaichan !== false // Default to true
   });
 }
 
@@ -209,7 +354,8 @@ function buildDefaultPrompt() {
     domain: 'general',
     playbook: null,
     missingSlots: [],
-    styleHints: {}
+    styleHints: {},
+    enableSmaichan: true // Default to Smaichan mode
   });
 }
 
@@ -220,5 +366,6 @@ export default {
   buildSystemPrompt,
   buildConversationPrompt,
   buildDomainPrompt,
-  buildDefaultPrompt
+  buildDefaultPrompt,
+  SMAICHAN_PERSONA // Export persona for reference
 };


### PR DESCRIPTION
- Add SMAICHAN_PERSONA constant with full character definition
- Modify buildSystemPrompt() to support enableSmaichan parameter (default: true)
- Add conditional logic for Smaichan vs traditional mode
- Include domain-specific adjustments for Smaichan's speaking style
- Export persona for reference in default export

This allows the chatbot to respond with Smaichan's personality while maintaining all existing functionality for slot extraction, FAQ matching, and business logic.

🤖 Generated with [Claude Code](https://claude.ai/code)